### PR TITLE
fix: build with Go 1.26.4 to remediate stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.1


### PR DESCRIPTION
Bump the Go build toolchain to 1.26.4 so release binaries no longer carry Go stdlib vulnerabilities flagged by Trivy on the built Harbor images (CVE-2026-27145 crypto/x509, CVE-2026-33811/33814 net, CVE-2026-42504/42507 net/textproto, CVE-2026-39820/39823/39825/39826 net/mail+html/template, etc.; all fixed in Go 1.26.4).

Part of Harbor 2.14.3 vulnerability remediation (DEVOPS-44168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)